### PR TITLE
(iOS) Override CDVPlugin class abstract method `handleOpenURL` instea…

### DIFF
--- a/src/ios/AppDelegate+Wechat.m
+++ b/src/ios/AppDelegate+Wechat.m
@@ -34,10 +34,10 @@ static BOOL swizzled = NO;
     }
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    CDVWechat *cdvWechat = [self.viewController getCommandInstance:@"wechat"];
-    return [cdvWechat handleWechatOpenURL:url];
-}
+//- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+//    CDVWechat *cdvWechat = [self.viewController getCommandInstance:@"wechat"];
+//    return [cdvWechat handleWechatOpenURL:url];
+//}
 
 - (BOOL)swizzleApplication:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
     if (![userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {


### PR DESCRIPTION
…d of implementing app delegate `application:openURL:options` to prevent conflicts with other plugins.

cordova-plugin-customurlscheme will not woking under current wechat plugin for ios.
That is, open the schema link on safari, the app should open a specific page. 
Now, it just open the app, rather than jump to that specific page.

I comment some code in AppDelegate+Wechat.m, and it's working again.
So I'd like to create a pull-request for this issue.